### PR TITLE
Version and documentation updates

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: 1.24.x
+  GO_VERSION: 1.25.x
 
 jobs:
   lint:

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -19,7 +19,7 @@ permissions:
   security-events: write
 
 env:
-  GO_VERSION: 1.24.x
+  GO_VERSION: 1.25.x
   OUTPUT_FILE: results.sarif
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - 1.24.x
+          - 1.25.x
         platform:
           - macos-latest
           - windows-latest

--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -5,7 +5,7 @@
 # touch: https://github.com/nicholas-fedor/touch/                                                    #
 # Mockery: https://vektra.github.io/mockery/latest/                                                  #
 # Configuration: https://vektra.github.io/mockery/latest/configuration                               #
-# Mockery Version: 3.3.2                                                                             #
+# Mockery Version: 3.5.2                                                                             #
 #                                                                                                    #
 ######################################################################################################
 
@@ -13,7 +13,7 @@
 # Mockery Usage                                                                                      #
 #                                                                                                    #
 # Install Mockery:                                                                                   #
-# go install github.com/vektra/mockery/v3@v3.3.2                                                     #
+# go install github.com/vektra/mockery/v3@v3.5.2                                                     #
 #                                                                                                    #
 # Run CLI command from root:                                                                         #
 # mockery                                                                                            #

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/spf13/pflag v1.0.7 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,9 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
-github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.7 h1:vN6T9TfwStFPFM5XzjsvmzZkLuaLX+HS+0SeFLRgU6M=
+github.com/spf13/pflag v1.0.7/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=


### PR DESCRIPTION
- Update workflow files to reference Go v1.25.x
- Update comments in Mockery configuration file to reference v3.5.2
- Update Go dependency spf13/pflag from v1.0.6 to v1.0.7